### PR TITLE
Add convo request event

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -347,7 +347,7 @@ public:
   static inline QStringList DEFAULT_COMBAT_MESSAGE_EVENT_TYPES() {
     return QStringList{"fleet_invite",  "follow_warp", "regroup",
                        "compression",   "decloak",     "crystal_broke",
-                       "mining_stopped"};
+                       "mining_stopped", "convo_request"};
   }
 
 private:
@@ -581,10 +581,10 @@ private:
 
   static inline QMap<QString, QString> DEFAULT_EVENT_COLORS() {
     return QMap<QString, QString>{
-        {"fleet_invite", "#4A9EFF"},  {"follow_warp", "#FFD700"},
-        {"regroup", "#FF8C42"},       {"compression", "#7FFF00"},
-        {"decloak", "#FFFFFF"},       {"crystal_broke", "#008080"},
-        {"mining_stopped", "#FF6B6B"}};
+        {"fleet_invite", "#4A9EFF"},    {"follow_warp", "#FFD700"},
+        {"regroup", "#FF8C42"},         {"compression", "#7FFF00"},
+        {"decloak", "#FFFFFF"},         {"crystal_broke", "#008080"},
+        {"mining_stopped", "#FF6B6B"}, {"convo_request", "#FFAAFF"}};
   }
 
   static constexpr const char *KEY_MINING_TIMEOUT_SECONDS =

--- a/include/configdialog.h
+++ b/include/configdialog.h
@@ -343,6 +343,7 @@ private:
   QCheckBox *m_combatEventCompressionCheck;
   QCheckBox *m_combatEventDecloakCheck;
   QCheckBox *m_combatEventCrystalBrokeCheck;
+  QCheckBox *m_combatEventConvoRequestCheck;
 
   QCheckBox *m_combatEventMiningStopCheck;
   QSpinBox *m_miningTimeoutSpin;

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -2522,6 +2522,10 @@ void ConfigDialog::createDataSourcesPage() {
   combatTabs->addTab(
       createEventTab("decloak", "Decloak Events", m_combatEventDecloakCheck),
       "Decloak");
+  combatTabs->addTab(
+    createEventTab("convo_request", "Convo Request", m_combatEventConvoRequestCheck),
+    "Convo Request"
+  );  
   combatTabs->addTab(createEventTab("crystal_broke", "Mining Crystal Broke",
                                     m_combatEventCrystalBrokeCheck),
                      "Crystal Broke");
@@ -2876,6 +2880,7 @@ void ConfigDialog::createDataSourcesPage() {
   connectEventCheckbox("fleet_invite", m_combatEventFleetInviteCheck);
   connectEventCheckbox("follow_warp", m_combatEventFollowWarpCheck);
   connectEventCheckbox("regroup", m_combatEventRegroupCheck);
+  connectEventCheckbox("regroup", m_combatEventConvoRequestCheck);
   connectEventCheckbox("compression", m_combatEventCompressionCheck);
   connectEventCheckbox("decloak", m_combatEventDecloakCheck);
   connectEventCheckbox("crystal_broke", m_combatEventCrystalBrokeCheck);
@@ -2901,6 +2906,7 @@ void ConfigDialog::createDataSourcesPage() {
         m_combatEventCompressionCheck->setEnabled(checked);
         m_combatEventDecloakCheck->setEnabled(checked);
         m_combatEventCrystalBrokeCheck->setEnabled(checked);
+        m_combatEventConvoRequestCheck->setEnabled(checked);
         m_combatEventMiningStopCheck->setEnabled(checked);
 
         bool miningStopChecked = m_combatEventMiningStopCheck->isChecked();
@@ -2914,6 +2920,7 @@ void ConfigDialog::createDataSourcesPage() {
             {"compression", m_combatEventCompressionCheck},
             {"decloak", m_combatEventDecloakCheck},
             {"crystal_broke", m_combatEventCrystalBrokeCheck},
+            {"convo_request", m_combatEventConvoRequestCheck},
             {"mining_stopped", m_combatEventMiningStopCheck}};
 
         for (auto it = eventCheckboxes.constBegin();
@@ -3546,6 +3553,21 @@ void ConfigDialog::setupBindings() {
       },
       true));
 
+    m_bindingManager.addBinding(BindingHelpers::bindCheckBox(
+      m_combatEventConvoRequestCheck,
+      [&config]() { return config.isCombatEventTypeEnabled("convo_request"); },
+      [&config](bool value) {
+        QStringList types = config.enabledCombatEventTypes();
+        if (value && !types.contains("convo_request")) {
+          types << "convo_request";
+          config.setEnabledCombatEventTypes(types);
+        } else if (!value) {
+          types.removeAll("convo_request");
+          config.setEnabledCombatEventTypes(types);
+        }
+      },
+      true));
+
   m_bindingManager.addBinding(BindingHelpers::bindCheckBox(
       m_combatEventMiningStopCheck,
       [&config]() { return config.isCombatEventTypeEnabled("mining_stopped"); },
@@ -3854,6 +3876,7 @@ void ConfigDialog::loadSettings() {
   m_combatEventFollowWarpCheck->setEnabled(combatMessagesEnabled);
   m_combatEventRegroupCheck->setEnabled(combatMessagesEnabled);
   m_combatEventCompressionCheck->setEnabled(combatMessagesEnabled);
+  m_combatEventConvoRequestCheck->setEnabled(combatMessagesEnabled);
   m_combatEventMiningStopCheck->setEnabled(combatMessagesEnabled);
 
   bool miningStopChecked = m_combatEventMiningStopCheck->isChecked();
@@ -3865,6 +3888,7 @@ void ConfigDialog::loadSettings() {
       {"follow_warp", m_combatEventFollowWarpCheck},
       {"regroup", m_combatEventRegroupCheck},
       {"compression", m_combatEventCompressionCheck},
+      {"convo_request", m_combatEventConvoRequestCheck},
       {"mining_stopped", m_combatEventMiningStopCheck}};
 
   for (auto it = eventCheckboxes.constBegin(); it != eventCheckboxes.constEnd();
@@ -7433,6 +7457,8 @@ void ConfigDialog::onResetCombatMessagesDefaults() {
         checkbox = m_combatEventRegroupCheck;
       else if (eventType == "compression")
         checkbox = m_combatEventCompressionCheck;
+      else if (eventType == "convo_request")
+        checkbox = m_combatEventConvoRequestCheck;
       else if (eventType == "mining_stopped")
         checkbox = m_combatEventMiningStopCheck;
 


### PR DESCRIPTION
Added a new tab for convo requests.

Caveat: Only works if the receiver doesn't have the requester as a contact. Would need to add another log worker checking Chatlogs > Private Chat .....` for new files.

Could also rename to `DM Request`, `Convo Request` sounds kinda naff.


[![Image from Gyazo](https://i.gyazo.com/2b8f3435cfef075fd5049d2593b8e16e.gif)](https://gyazo.com/2b8f3435cfef075fd5049d2593b8e16e)