### PR TITLE
Fix event log sound notifications and Settings test playback for MP3 files

### DIFF
--- a/include/configdialog.h
+++ b/include/configdialog.h
@@ -13,7 +13,6 @@
 #include <QPushButton>
 #include <QSet>
 #include <QSlider>
-#include <QSoundEffect>
 #include <QSpinBox>
 #include <QStackedWidget>
 #include <QTableWidget>
@@ -25,6 +24,8 @@ class QVBoxLayout;
 class ThumbnailWidget;
 class QNetworkAccessManager;
 class QScrollArea;
+class QAudioOutput;
+class QMediaPlayer;
 
 class ConfigDialog : public QDialog {
   Q_OBJECT
@@ -441,7 +442,8 @@ private:
   QNetworkAccessManager *m_networkManager;
   QString m_latestReleaseUrl;
 
-  std::unique_ptr<QSoundEffect> m_testSoundEffect;
+  std::unique_ptr<QAudioOutput> m_testAudioOutput;
+  std::unique_ptr<QMediaPlayer> m_testSoundPlayer;
 
   SettingBindingManager m_bindingManager;
 };

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -7,7 +7,6 @@
 #include <QObject>
 #include <QPoint>
 #include <QPointer>
-#include <QSoundEffect>
 #include <QSystemTrayIcon>
 #include <QTimer>
 #include <QVector>
@@ -20,6 +19,8 @@ class HotkeyManager;
 class ConfigDialog;
 class ChatLogReader;
 class ProtocolHandler;
+class QAudioOutput;
+class QMediaPlayer;
 struct CycleGroup;
 
 /// Pre-computed shared state for bulk thumbnail visibility updates
@@ -92,7 +93,8 @@ private:
   std::unique_ptr<WindowCapture> windowCapture;
   std::unique_ptr<HotkeyManager> hotkeyManager;
   std::unique_ptr<ChatLogReader> m_chatLogReader;
-  std::unique_ptr<QSoundEffect> m_soundEffect;
+  std::unique_ptr<QAudioOutput> m_soundAudioOutput;
+  std::unique_ptr<QMediaPlayer> m_soundPlayer;
   std::unique_ptr<ProtocolHandler> m_protocolHandler;
   std::unique_ptr<QLocalServer> m_ipcServer;
   QHash<HWND, ThumbnailWidget *> thumbnails;

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -8,6 +8,7 @@
 #include "version.h"
 #include "windowcapture.h"
 #include <Psapi.h>
+#include <QAudioOutput>
 #include <QColorDialog>
 #include <QDesktopServices>
 #include <QFileDialog>
@@ -23,6 +24,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMap>
+#include <QMediaPlayer>
 #include <QMessageBox>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
@@ -3013,13 +3015,22 @@ void ConfigDialog::createDataSourcesPage() {
     connect(playBtn, &QPushButton::clicked, this, [this, eventType]() {
       QString soundFile = Config::instance().combatEventSoundFile(eventType);
       if (!soundFile.isEmpty() && QFile::exists(soundFile)) {
-        if (!m_testSoundEffect) {
-          m_testSoundEffect = std::make_unique<QSoundEffect>();
+        if (!m_testAudioOutput) {
+          m_testAudioOutput = std::make_unique<QAudioOutput>();
         }
-        m_testSoundEffect->setSource(QUrl::fromLocalFile(soundFile));
+        if (!m_testSoundPlayer) {
+          m_testSoundPlayer = std::make_unique<QMediaPlayer>();
+          m_testSoundPlayer->setAudioOutput(m_testAudioOutput.get());
+        }
+        const QUrl sourceUrl = QUrl::fromLocalFile(soundFile);
+        if (m_testSoundPlayer->source() != sourceUrl) {
+          m_testSoundPlayer->setSource(sourceUrl);
+        } else {
+          m_testSoundPlayer->setPosition(0);
+        }
         int volume = Config::instance().combatEventSoundVolume(eventType);
-        m_testSoundEffect->setVolume(volume / 100.0);
-        m_testSoundEffect->play();
+        m_testAudioOutput->setVolume(volume / 100.0);
+        m_testSoundPlayer->play();
       }
     });
     m_eventSoundPlayButtons[eventType] = playBtn;
@@ -3307,13 +3318,22 @@ void ConfigDialog::createDataSourcesPage() {
     QString soundFile =
         Config::instance().combatEventSoundFile("mining_stopped");
     if (!soundFile.isEmpty() && QFile::exists(soundFile)) {
-      if (!m_testSoundEffect) {
-        m_testSoundEffect = std::make_unique<QSoundEffect>();
+      if (!m_testAudioOutput) {
+        m_testAudioOutput = std::make_unique<QAudioOutput>();
       }
-      m_testSoundEffect->setSource(QUrl::fromLocalFile(soundFile));
+      if (!m_testSoundPlayer) {
+        m_testSoundPlayer = std::make_unique<QMediaPlayer>();
+        m_testSoundPlayer->setAudioOutput(m_testAudioOutput.get());
+      }
+      const QUrl sourceUrl = QUrl::fromLocalFile(soundFile);
+      if (m_testSoundPlayer->source() != sourceUrl) {
+        m_testSoundPlayer->setSource(sourceUrl);
+      } else {
+        m_testSoundPlayer->setPosition(0);
+      }
       int volume = Config::instance().combatEventSoundVolume("mining_stopped");
-      m_testSoundEffect->setVolume(volume / 100.0);
-      m_testSoundEffect->play();
+      m_testAudioOutput->setVolume(volume / 100.0);
+      m_testSoundPlayer->play();
     }
   });
   m_eventSoundPlayButtons["mining_stopped"] = miningSoundPlayBtn;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8,6 +8,7 @@
 #include "thumbnailwidget.h"
 #include "windowcapture.h"
 #include <QAction>
+#include <QAudioOutput>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -16,6 +17,7 @@
 #include <QGuiApplication>
 #include <QIcon>
 #include <QLocalSocket>
+#include <QMediaPlayer>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
@@ -36,9 +38,11 @@ QPointer<MainWindow> MainWindow::s_instance;
 MainWindow::MainWindow(QObject *parent)
     : QObject(parent), windowCapture(std::make_unique<WindowCapture>()),
       hotkeyManager(std::make_unique<HotkeyManager>()),
-      m_soundEffect(std::make_unique<QSoundEffect>()),
+      m_soundAudioOutput(std::make_unique<QAudioOutput>()),
+      m_soundPlayer(std::make_unique<QMediaPlayer>()),
       m_notLoggedInCycleIndex(-1), m_nonEVECycleIndex(-1) {
   s_instance = this;
+  m_soundPlayer->setAudioOutput(m_soundAudioOutput.get());
 
   connect(hotkeyManager.get(), &HotkeyManager::characterHotkeyPressed, this,
           &MainWindow::activateCharacter);
@@ -2491,10 +2495,15 @@ void MainWindow::onCombatEventDetected(const QString &characterName,
     if (cfg.combatEventSoundEnabled(eventType)) {
       QString soundFile = cfg.combatEventSoundFile(eventType);
       if (!soundFile.isEmpty() && QFile::exists(soundFile)) {
-        m_soundEffect->setSource(QUrl::fromLocalFile(soundFile));
+        const QUrl sourceUrl = QUrl::fromLocalFile(soundFile);
+        if (m_soundPlayer->source() != sourceUrl) {
+          m_soundPlayer->setSource(sourceUrl);
+        } else {
+          m_soundPlayer->setPosition(0);
+        }
         qreal volume = cfg.combatEventSoundVolume(eventType) / 100.0;
-        m_soundEffect->setVolume(volume);
-        m_soundEffect->play();
+        m_soundAudioOutput->setVolume(volume);
+        m_soundPlayer->play();
         qDebug() << "MainWindow: Playing sound for" << eventType
                  << "- File:" << soundFile << "- Volume:" << volume;
       } else {


### PR DESCRIPTION
This PR fixes sound notification playback for event logs and the Settings "Test" buttons when using .mp3 files.

### Summary of changes
- Replaced QSoundEffect playback with QMediaPlayer + QAudioOutput in:
- Runtime combat/event notification playback (MainWindow)
- Settings sound test playback (ConfigDialog, including mining stopped test)

### Why
QSoundEffect is not reliable for compressed formats like .mp3 in Qt6 setups. QMediaPlayer is the correct backend for this use case.

### Behavior improvements
- .mp3 files selected in settings now play from the Test button.
- Event-triggered alert sounds now play with the same backend.
- Repeated playback of the same file restarts cleanly via setPosition(0).